### PR TITLE
Remove duplicate bucket name from s3 object url

### DIFF
--- a/controllers/OfferController.js
+++ b/controllers/OfferController.js
@@ -1,5 +1,6 @@
 
 const Offer = require("../models/Offers");
+const getAmazonS3Url = require("./utils");
 
 const create_new_offer = async (req, res, next) => {
 
@@ -7,9 +8,8 @@ const create_new_offer = async (req, res, next) => {
     const { title, description, quantity, image, address, price, timeSlot, specials, creatorId, categories, date } = req.body;
 
     //Getting array from Frontend needs to be parsed
-    console.log(req.file.location)
     const data = {
-      title: title, description:description, quantity:quantity, address:address, image: req.file.location, price:price, timeSlot:timeSlot,
+      title: title, description:description, quantity:quantity, address:address, image: getAmazonS3Url(req.file.location, req.file.key), price:price, timeSlot:timeSlot,
       specials: JSON.parse(specials), creatorId:req.user._id, categories:categories, date:date
     }
     const newOffer = await Offer.create(data);

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -2,6 +2,7 @@ const User = require("../models/Users");
 const Rating = require("../models/Ratings");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
+const getAmazonS3Url = require("./utils");
 
 
 const registerUser = async (req, res, next) => {
@@ -9,7 +10,6 @@ const registerUser = async (req, res, next) => {
   const {
     body: { userName, email, profilePic, password, date },
   } = req;
-  console.log(req.file);
 
   const found = await User.findOne({ email });
   if (found) return res.status(400).send("Error Occurs");
@@ -21,7 +21,7 @@ const registerUser = async (req, res, next) => {
     password: hash,
     email,
     date: date,
-    profilePic: req.file.location
+    profilePic: getAmazonS3Url(req.file.location, req.file.key)
   });
   
 

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -1,0 +1,14 @@
+const { AWS_BUCKET_NAME } = process.env;
+
+const getAmazonS3Url = (url, key) => {
+    let tmpUrl = url.split(AWS_BUCKET_NAME + '.');
+    if (tmpUrl.length == 2) {
+        const s3Url = tmpUrl[1].split('/' + key);
+        if (s3Url.length >= 1) {
+            return `https://${AWS_BUCKET_NAME}.${s3Url[0]}/${key}`;
+        }
+    }
+    return url;
+}
+
+module.exports = getAmazonS3Url;


### PR DESCRIPTION
In local, s3 object url was correct as shown in s3 properties. However, in render server saved urls had extra bucket name in object url.

This commit always saves correct url no matter the environments.